### PR TITLE
[chore][infra] Keycloak 개발/배포 환경 분리 및 healthcheck 수정

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -13,3 +13,7 @@ KEYCLOAK_ADMIN_PASSWORD=
 # REDIS_PORT=6379
 # KAFKA_PORT=9092
 # KAFKA_UI_PORT=8989
+
+# 배포 환경 전용 (docker-compose.prod.yml 사용 시)
+# .env.prod 파일을 별도로 생성하여 EC2에만 보관 (git 제외)
+# KC_DB_URL은 docker-compose.prod.yml에서 자동 조합되므로 별도 설정 불필요

--- a/.gitignore
+++ b/.gitignore
@@ -1,1 +1,2 @@
 .env
+.env.prod

--- a/docker-compose.override.yml
+++ b/docker-compose.override.yml
@@ -1,0 +1,30 @@
+# ============================================================
+# 로컬 개발 환경용 override 파일
+# ============================================================
+#
+# -- 자동 적용
+# Docker Compose는 docker-compose.yml과 동일 디렉토리에
+# docker-compose.override.yml이 존재하면 자동으로 병합합니다.
+# 별도 -f 옵션 없이 아래 커맨드로 로컬 개발 환경을 구성하시면 됩니다.
+#
+#   docker compose up -d
+#
+# -- 환경 분리 이유
+# Keycloak의 start-dev(개발 모드)와 start(운영환경 모드)는
+# 실행 방식과 헬스체크 동작 방식이 달라 하나의 파일로 관리할 수 없습니다.
+#
+#   start-dev : H2 인메모리 DB, 빠른 시작, 헬스체크 → 9000 포트
+#   start     : PostgreSQL 연동, 보안 활성화, 헬스체크 → 9000 포트
+#
+# 로컬 개발 편의를 위한 설정만 추가하세요.
+# 배포에 반영되어야 하는 변경은 docker-compose.prod.yml에 작성합니다.
+# ============================================================
+services:
+  keycloak:
+    command: start-dev --import-realm
+    healthcheck:
+      test: ["CMD", "bash", "-c", "exec 3<>/dev/tcp/localhost/9000 && printf 'GET /health/ready HTTP/1.0\\r\\nHost: localhost\\r\\n\\r\\n' >&3 && grep -q UP <&3"]
+      interval: 15s
+      timeout: 10s
+      retries: 10
+      start_period: 60s

--- a/docker-compose.prod.yml
+++ b/docker-compose.prod.yml
@@ -1,0 +1,75 @@
+# ============================================================
+# AWS 배포 환경용 Compose 파일
+# ============================================================
+#
+# [실행 방법 - EC2에서]
+#
+#   1) 최초 배포 또는 설정 변경 시
+#      docker compose -f docker-compose.yml -f docker-compose.prod.yml \
+#        --env-file .env.prod up -d
+#
+#   2) 특정 서비스만 재시작
+#      docker compose -f docker-compose.yml -f docker-compose.prod.yml \
+#        --env-file .env.prod restart keycloak
+#
+#   3) 컨테이너 정리 후 재배포
+#      docker compose -f docker-compose.yml -f docker-compose.prod.yml \
+#        --env-file .env.prod down
+#      docker compose -f docker-compose.yml -f docker-compose.prod.yml \
+#        --env-file .env.prod up -d
+#
+# [.env.prod 파일 위치]
+# .env.prod는 보안 자격증명을 포함하므로 git에 포함하지 않습니다.
+# EC2 인스턴스의 infra/ 디렉토리에 직접 생성하여 사용합니다.
+# 필요한 변수 목록은 .env.example을 참고하세요.
+#
+# [이미지 업데이트가 필요한 경우]
+# Keycloak 이미지 버전을 올리거나 설정이 바뀐 경우:
+#   docker compose -f docker-compose.yml -f docker-compose.prod.yml \
+#     --env-file .env.prod pull keycloak
+#   docker compose -f docker-compose.yml -f docker-compose.prod.yml \
+#     --env-file .env.prod up -d keycloak
+#
+# [환경 분리 이유]
+# 이 파일은 docker-compose.yml의 keycloak 서비스 설정을 덮어씁니다.
+# override.yml(로컬)과 prod.yml(배포)을 분리한 이유:
+#   - 로컬은 start-dev(H2 DB), 배포는 start(PostgreSQL) - 실행 방식이 근본적으로 다름
+#   - 배포 환경 자격증명(.env.prod)을 git에서 완전히 분리하기 위함
+# ============================================================
+
+services:
+  keycloak:
+    # 프로덕션 모드: 보안 설정 활성화, PostgreSQL 연동
+    # start-dev와 달리 start는 DB 설정이 필수입니다
+    command: start --import-realm
+
+    environment:
+      KC_BOOTSTRAP_ADMIN_USERNAME: ${KEYCLOAK_ADMIN}
+      KC_BOOTSTRAP_ADMIN_PASSWORD: ${KEYCLOAK_ADMIN_PASSWORD}
+      KC_HEALTH_ENABLED: "true"
+
+      # PostgreSQL 연동 — H2 인메모리 대신 영속성 확보
+      # 컨테이너 재시작 시에도 사용자/세션 데이터가 보존됩니다
+      KC_DB: postgres
+      KC_DB_URL: jdbc:postgresql://postgresql:5432/${POSTGRES_DB}
+      KC_DB_USERNAME: ${POSTGRES_USER}
+      KC_DB_PASSWORD: ${POSTGRES_PASSWORD}
+
+      # AWS 환경에서 HTTP 허용
+      # HTTPS 터미네이션을 ALB 또는 리버스 프록시에서 처리하는 구조에서는
+      # Keycloak 자체는 HTTP로 동작해도 무방합니다
+      KC_HTTP_ENABLED: "true"
+      KC_HOSTNAME_STRICT: "false"
+
+    # PostgreSQL이 healthy 상태가 된 후 Keycloak을 기동합니다
+    # (DB 없이 start 모드로 기동하면 즉시 실패)
+    depends_on:
+      postgresql:
+        condition: service_healthy
+
+    healthcheck:
+      test: ["CMD", "bash", "-c", "exec 3<>/dev/tcp/localhost/9000 && printf 'GET /health/ready HTTP/1.0\\r\\nHost: localhost\\r\\n\\r\\n' >&3 && grep -q UP <&3"]
+      interval: 15s
+      timeout: 10s
+      retries: 10
+      start_period: 90s

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -90,7 +90,6 @@ services:
     image: quay.io/keycloak/keycloak:26.0
     container_name: first-ticket-keycloak
     restart: on-failure:3
-    command: start-dev --import-realm
     environment:
       KC_BOOTSTRAP_ADMIN_USERNAME: ${KEYCLOAK_ADMIN}
       KC_BOOTSTRAP_ADMIN_PASSWORD: ${KEYCLOAK_ADMIN_PASSWORD}
@@ -100,12 +99,6 @@ services:
       - keycloak-data:/opt/keycloak/data
     ports:
       - "${KEYCLOAK_PORT:-8180}:8080"
-    healthcheck:
-      test: ["CMD-SHELL", "curl -f http://localhost:9000/health/ready || exit 1"]
-      interval: 15s
-      timeout: 10s
-      retries: 10
-      start_period: 60s
     networks:
       - first-ticket-network
 


### PR DESCRIPTION
## 🌱 설명
- Keycloak 컨테이너가 AWS 배포 환경에서 항상 `unhealthy` 상태였던 문제를 해결
- 로컬 개발 환경과 AWS 배포 환경을 docker-compose override 파일 패턴으로 분리

**문제 원인**
- `start-dev` 명령(개발 모드)으로 실행 중 → H2 인메모리 DB 사용, 재시작 시 데이터 초기화
- healthcheck가 `curl`을 사용하나 Keycloak 26 이미지에 `curl`/`wget` 미포함 → 항상 실패
- dev/prod 모드 모두 관리 포트(9000)에서 `/health/ready` 응답 → 포트는 동일하나 도구 문제

**해결 방법**
- `docker-compose.override.yml`: 로컬 개발용 (`start-dev`, 자동 적용)
- `docker-compose.prod.yml`: AWS 배포용 (`start` + PostgreSQL 연동)
- healthcheck를 `bash /dev/tcp`로 교체 (외부 도구 불필요)


## 📌 관련 이슈
- close #10 


## 💻 커밋 유형
> 해당하는 항목에 `x`를 채워주세요.
- [ ] feat     : 새로운 기능 추가
- [ ] fix      : 버그 수정 (긴급 핫픽스 포함)
- [ ] refactor : 리팩토링
- [x] chore    : 빌드 설정, 의존성 업데이트 등
- [ ] docs     : 문서 수정
- [ ] comment  : 주석 추가 및 변경
- [ ] rename   : 파일 / 폴더 이동 또는 이름 변경
- [ ] remove   : 파일 삭제
- [ ] test     : 테스트 코드 추가 / 수정


## 📝 체크리스트
> PR 올리기 전에 아래 항목을 확인해주세요.
- [x] develop 브랜치 기준으로 feature 브랜치를 생성했나요?
- [x] 코드 컨벤션 및 스타일 가이드를 준수했나요?
- [x] 관련 이슈와 연결했나요?
- [x] 설명이 필요한 부분 / 어려운 부분 / 공유가 필요한 부분에 주석을 추가했습니다.
- [x] 제가 작성한 코드를 스스로 리뷰했습니다.
- [x] 기존 테스트와 충돌하지 않음을 확인했나요?


## 📚 추가 설명
**로컬 실행 방법 (변경 없음)**
```
docker compose up -d   # override.yml 자동 적용
```

### **AWS 배포 실행 방법** (SSH)

```
docker compose -f docker-compose.yml -f docker-compose.prod.yml --env-file .env.prod up -d
```

### **Keycloak 26 healthcheck 이슈 참고**

- Keycloak 26 이미지는 경량화로 인해 `curl`/`wget`이 제거되어 있습니다.
- 커뮤니티 공인 해결책인 `bash /dev/tcp` 방식을 채택했습니다.