### PR TITLE
[chore][infra] KC_HOSTNAME_STRICT_HTTPS 추가 - Keycloak admin console http 허용

### DIFF
--- a/docker-compose.prod.yml
+++ b/docker-compose.prod.yml
@@ -60,6 +60,7 @@ services:
       # Keycloak 자체는 HTTP로 동작해도 무방합니다
       KC_HTTP_ENABLED: "true"
       KC_HOSTNAME_STRICT: "false"
+      KC_HOSTNAME_STRICT_HTTPS: "false"
 
     healthcheck:
       test: ["CMD", "bash", "-c", "exec 3<>/dev/tcp/localhost/9000 && printf 'GET /health/ready HTTP/1.0\\r\\nHost: localhost\\r\\n\\r\\n' >&3 && grep -q UP <&3"]


### PR DESCRIPTION
- KC_HOSTNAME_STRICT_HTTPS 추가 - Keycloak admin console http 허용시킵니다.
- Keycloak이 프로덕션 모드에서 admin 콘솔 인증 흐름을 HTTPS로 강제 리다이렉트하기 때문
- 따라서 해당 옵션을 false처리합니다.