### PR TITLE
Change sslRequired setting from 'external' to 'none'

### DIFF
--- a/keycloak/realm-export-prod.json
+++ b/keycloak/realm-export-prod.json
@@ -26,7 +26,7 @@
   "oauth2DeviceCodeLifespan": 600,
   "oauth2DevicePollingInterval": 5,
   "enabled": true,
-  "sslRequired": "external",
+  "sslRequired": "none",
   "registrationAllowed": false,
   "registrationEmailAsUsername": true,
   "rememberMe": false,


### PR DESCRIPTION
- keycloak Admin console의 https 자동 리다이렉트 설정을 끕니다.