### PR TITLE
[chore][infra] EC2 배포 환경 Prometheus 모니터링 설정 추가

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,7 @@
 .env
 .env.prod
+
+monitoring/prometheus/targets.json
+monitoring/prometheus/targets.json.tmp
+monitoring/prometheus/update.log
+

--- a/docker-compose.prod.yml
+++ b/docker-compose.prod.yml
@@ -77,6 +77,7 @@ services:
   prometheus:
     volumes:
       - ./monitoring/prometheus/prometheus-prod.yml:/etc/prometheus/prometheus.yml:ro
+      - ./monitoring/prometheus:/etc/prometheus/config:ro
       - prometheus-data:/prometheus
 
   # ── 배포 환경에서 사용하지 않는 서비스 비활성화 ──────────────────

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -104,7 +104,7 @@ services:
   # ── 모니터링 ──────────────────────────────────────────────
 
   prometheus:
-    image: prom/prometheus:v2.51.0
+    image: prom/prometheus:v2.53.0
     container_name: first-ticket-prometheus
     restart: on-failure:3
     ports:

--- a/monitoring/prometheus/prometheus-prod.yml
+++ b/monitoring/prometheus/prometheus-prod.yml
@@ -1,25 +1,11 @@
 global:
   scrape_interval: 15s
   evaluation_interval: 15s
-  scrape_timeout: 10s
 
 scrape_configs:
-  - job_name: 'ecs-services'
+  - job_name: 'ecs-file-sd'
     metrics_path: '/actuator/prometheus'
-    aws_sd_configs:
-      - region: ap-northeast-2
-        type: Service
-        port: 8080
-        filters:
-          - name: namespace-name
-            values:
-              - first-ticket
-    relabel_configs:
-      # 서비스명을 job 라벨로 설정
-      - source_labels: [__meta_aws_sd_service_name]
-        target_label: job
-      # IP:PORT 설정
-      - source_labels: [__meta_aws_sd_instance_address]
-        regex: (.*)
-        target_label: __address__
-        replacement: '${1}:8080'
+    file_sd_configs:
+      - files:
+          - '/etc/prometheus/config/targets.json'
+        refresh_interval: 15s

--- a/monitoring/prometheus/update_targets.sh
+++ b/monitoring/prometheus/update_targets.sh
@@ -1,0 +1,56 @@
+#!/bin/bash
+
+# Cloud Map 서비스 리스트 (9개)
+SERVICES=(
+  "program-service"
+  "venue-service"
+  "payment-service"
+  "queue-service"
+  "booking-service"
+  "gateway-server"
+  "eureka-server"
+  "user-service"
+  "config-server"
+)
+
+REGION="ap-northeast-2"
+NAMESPACE="first-ticket"
+# 실제 파일이 저장될 절대 경로
+OUTPUT_FILE="/home/ubuntu/firstticket/infra/monitoring/prometheus/targets.json"
+TEMP_FILE="/home/ubuntu/firstticket/infra/monitoring/prometheus/targets.json.tmp"
+
+# JSON 시작
+echo "[" > $TEMP_FILE
+
+FIRST=true
+for SERVICE in "${SERVICES[@]}"; do
+  # AWS CLI로 IP 조회 (Attributes 내의 IP 추출)
+  IP=$(aws servicediscovery discover-instances \
+    --namespace-name $NAMESPACE \
+    --service-name $SERVICE \
+    --region $REGION \
+    --query 'Instances[0].Attributes.AWS_INSTANCE_IPV4' --output text)
+
+  # IP가 정상적으로 조회된 경우만 JSON에 추가
+  if [ "$IP" != "None" ] && [ -n "$IP" ]; then
+    # 첫 번째 원소가 아니면 이전 줄 끝에 콤마 추가
+    if [ "$FIRST" = false ]; then
+      echo "  ," >> $TEMP_FILE
+    fi
+    
+    echo "  {" >> $TEMP_FILE
+    echo "    \"targets\": [\"$IP:8080\"]," >> $TEMP_FILE
+    echo "    \"labels\": { \"job\": \"$SERVICE\" }" >> $TEMP_FILE
+    echo "  }" >> $TEMP_FILE
+    FIRST=false
+  fi
+done
+
+# JSON 끝
+echo "]" >> $TEMP_FILE
+
+# 임시 파일을 실제 파일로 교체 (파일 쓰기 중 읽기 에러 방지)
+mv $TEMP_FILE $OUTPUT_FILE
+
+echo "Targets updated at $(date)"
+


### PR DESCRIPTION
## 🌱 설명
- ECS 유동 IP 문제 해결을 위한 Prometheus 모니터링 자동화 설정 추가
- Cloud Map 기반 타겟 자동 업데이트 스크립트 추가
- Prometheus 버전 업그레이드 (v2.51.0 → v2.53.0)

## 📌 관련 이슈


## 💻 커밋 유형
> 해당하는 항목에 `x`를 채워주세요.
- [ ] feat     : 새로운 기능 추가
- [ ] fix      : 버그 수정 (긴급 핫픽스 포함)
- [ ] refactor : 리팩토링
- [x] chore    : 빌드 설정, 의존성 업데이트 등
- [ ] docs     : 문서 수정
- [ ] comment  : 주석 추가 및 변경
- [ ] rename   : 파일 / 폴더 이동 또는 이름 변경
- [ ] remove   : 파일 삭제
- [ ] test     : 테스트 코드 추가 / 수정


## 📝 체크리스트
> PR 올리기 전에 아래 항목을 확인해주세요.
- [ ] develop 브랜치 기준으로 feature 브랜치를 생성했나요?
- [ ] 코드 컨벤션 및 스타일 가이드를 준수했나요?
- [ ] 관련 이슈와 연결했나요?
- [ ] 설명이 필요한 부분 / 어려운 부분 / 공유가 필요한 부분에 주석을 추가했습니다.
- [ ] 제가 작성한 코드를 스스로 리뷰했습니다.
- [ ] 기존 테스트와 충돌하지 않음을 확인했나요?


## 📚 추가 설명
- ECS Fargate는 태스크 재시작 시 Private IP가 변경되어 Prometheus 고정 타겟 설정 불가
- `update_targets.sh`: AWS Cloud Map API로 실행 중인 태스크 IP를 1분마다 조회해 `targets.json` 갱신 (crontab 등록)
- `prometheus-prod.yml`: `file_sd_configs` 방식으로 변경
- `targets.json`, `targets.json.tmp`, `update.log`는 자동 생성 파일이므로 `.gitignore`에 추가
- `docker-compose.prod.yml`에 `monitoring/prometheus` 디렉토리 볼륨 마운트 추가로 `targets.json` 실시간 동기화


---

<!-- 
  ✅ 리뷰어 가이드 (이 섹션은 리뷰어에게만 보입니다 — 머지 전 삭제 불필요)
  
  리뷰할 때 아래 관점을 참고해주세요.
  
  [1] 도메인 로직 위치
      비즈니스 규칙이 Service가 아닌 Entity / VO / Enum 안에 있는지 확인해주세요.
      (Fat Service 안티패턴 방지)

  [2] 서비스 간 영향 범위
      Kafka 이벤트 구조, API 계약(Request/Response), X-User-Id 헤더 의존 등
      타 서비스에 영향을 주는 변경이 있다면 반드시 코멘트로 남겨주세요.

  [3] 예외 처리
      경계값, 동시성, 트랜잭션 롤백 시나리오가 처리되어 있는지 확인해주세요.

  [4] 리뷰 코멘트 규칙
      - 반드시 수정 : [must] 태그 사용   예) [must] 이 로직은 도메인으로 이동해야 합니다.
      - 제안 / 질문 : [nit] 태그 사용    예) [nit] 이렇게 바꾸면 어떨까요?
      nit(nitpick)은 "사소한 지적"을 의미하며,
      머지를 블로킹하지 않는 선택적 개선 제안을 뜻합니다.
-->